### PR TITLE
handle errors in verbose user friendly way

### DIFF
--- a/buse.c
+++ b/buse.c
@@ -94,7 +94,13 @@ int buse_main(const char* dev_file, const struct buse_operations *aop, void *use
   assert(!socketpair(AF_UNIX, SOCK_STREAM, 0, sp));
 
   nbd = open(dev_file, O_RDWR);
-  assert(nbd != -1);
+  if (nbd == -1) {
+    fprintf(stderr, 
+        "Failed to open `%s': %s\n"
+        "Is kernel module `nbd' is loaded and you have permissions "
+        "to access the device?\n", dev_file, strerror(errno));
+    return 1;
+  }
 
   assert(ioctl(nbd, NBD_SET_SIZE, aop->size) != -1);
   assert(ioctl(nbd, NBD_CLEAR_SOCK) != -1);

--- a/busexmp.c
+++ b/busexmp.c
@@ -74,7 +74,16 @@ static struct buse_operations aop = {
 
 int main(int argc, char *argv[])
 {
-  (void)(argc);
+  if (argc != 2)
+  {
+    fprintf(stderr, 
+        "Usage:\n"
+        "  %s /dev/nbd0\n"
+        "Don't forget to load nbd kernel module (`modprobe nbd`) and\n"
+        "run example from root.\n", argv[0]);
+    return 1;
+  }
+
   data = malloc(aop.size);
 
   return buse_main(argv[1], &aop, (void *)&xmpl_debug);


### PR DESCRIPTION
Add error handler on opening block device.
Add command line help to `busexmp` (so that it will not fail when running without arguments).