### PR TITLE
Fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ $(LIBOBJS): %.o: %.c
 
 test: $(TARGET)
 	PATH=$(PWD):$$PATH sudo test/busexmp.sh
+	PATH=$(PWD):$$PATH sudo test/signal_termination.sh
 
 clean:
 	rm -f $(TARGET) $(OBJS) $(STATIC_LIB)

--- a/test/busexmp.sh
+++ b/test/busexmp.sh
@@ -30,6 +30,7 @@ $DD if=/dev/urandom of="$TESTFILE" bs=16M count=1
 
 # attach BUSE device
 busexmp "$BLOCKDEV" &
+sleep 1
 BUSEPID=$!
 
 ### do checks ###

--- a/test/signal_termination.sh
+++ b/test/signal_termination.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 BLOCKDEV=/dev/nbd0
 


### PR DESCRIPTION
* both tests are run on `make test`

* disabled verbose execution (`set -x`)

* added sleep to allow BUSE to start before executing next instructions

  This is a bit dirty solution, but currently it's the only way, I guess.