### PR TITLE
Cleanup imports

### DIFF
--- a/buse.c
+++ b/buse.c
@@ -23,7 +23,7 @@
 #include <errno.h>
 #include <err.h>
 #include <fcntl.h>
-#include <linux/types.h>
+#include <linux/nbd.h>
 #include <netinet/in.h>
 #include <signal.h>
 #include <stdio.h>

--- a/buse.h
+++ b/buse.h
@@ -4,11 +4,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
-  /* Most of this file was copied from nbd.h in the nbd distribution. */
-#include <linux/types.h>
+
 #include <sys/types.h>
-#include <linux/nbd.h>
 
   struct buse_operations {
     int (*read)(void *buf, u_int32_t len, u_int64_t offset, void *userdata);


### PR DESCRIPTION
* `linux/nbd.h` included in implementation instead of in header, as it is unused in the header
* `linux/types.h` include seems not used