### PR TITLE
Use %llu and %lld macros for 64b ints.

### DIFF
--- a/busexmp.c
+++ b/busexmp.c
@@ -31,7 +31,7 @@ static void *data;
 static int xmp_read(void *buf, u_int32_t len, u_int64_t offset, void *userdata)
 {
   if (*(int *)userdata)
-    fprintf(stderr, "R - %lu, %u\n", offset, len);
+    fprintf(stderr, "R - %llu, %u\n", offset, len);
   memcpy(buf, (char *)data + offset, len);
   return 0;
 }
@@ -39,7 +39,7 @@ static int xmp_read(void *buf, u_int32_t len, u_int64_t offset, void *userdata)
 static int xmp_write(const void *buf, u_int32_t len, u_int64_t offset, void *userdata)
 {
   if (*(int *)userdata)
-    fprintf(stderr, "W - %lu, %u\n", offset, len);
+    fprintf(stderr, "W - %llu, %u\n", offset, len);
   memcpy((char *)data + offset, buf, len);
   return 0;
 }
@@ -60,7 +60,7 @@ static int xmp_flush(void *userdata)
 static int xmp_trim(u_int64_t from, u_int32_t len, void *userdata)
 {
   if (*(int *)userdata)
-    fprintf(stderr, "T - %lu, %u\n", from, len);
+    fprintf(stderr, "T - %llu, %u\n", from, len);
   return 0;
 }
 

--- a/loopback.c
+++ b/loopback.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     err = ioctl(fd, BLKGETSIZE64, &size);
     assert(err != -1);
     (void)err;
-    fprintf(stderr, "The size of this device is %ld bytes.\n", size);
+    fprintf(stderr, "The size of this device is %lld bytes.\n", size);
     bop.size = size;
 
     buse_main(argv[2], &bop, NULL);


### PR DESCRIPTION
This fixes build warnings on armv7l (a 32bit ARM).

Also tested on x86_64 – still works, and there are no new warnings.